### PR TITLE
Update admin auth url to v3 instead of v2.0

### DIFF
--- a/windows/installnova.ps1
+++ b/windows/installnova.ps1
@@ -78,12 +78,12 @@ $msiArgs = "/i $msi /qn /l*v $msiLogPath " + `
 "NEUTRONADMINTENANTNAME=service " +
 "NEUTRONADMINUSERNAME=neutron " +
 "NEUTRONADMINPASSWORD=$Password " +
-"NEUTRONADMINAUTHURL=http://${DevstackHost}:35357/v2.0 " +
+"NEUTRONADMINAUTHURL=http://${DevstackHost}:35357/v3 " +
 
 "CEILOMETERADMINTENANTNAME=service " +
 "CEILOMETERADMINUSERNAME=ceilometer " +
 "CEILOMETERADMINPASSWORD=$Password " +
-"CEILOMETERADMINAUTHURL=http://${DevstackHost}:35357/v2.0 "
+"CEILOMETERADMINAUTHURL=http://${DevstackHost}:35357/v3 "
 
 if ($domainName -and $features -ccontains "LiveMigration") {
     $msiArgs += "LIVEMIGRAUTHTYPE=1 " +


### PR DESCRIPTION
v2.0 is no longer supported in Mitaka, which can cause issues with the driver. This will lead to test failures.