### PR TITLE
Fixes neutron agent checks

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -120,12 +120,12 @@ function get_nova_service_hosts() {
 function check_neutron_agent_up() {
     local host_name=$1
     local agent_type=${2:-"HyperV agent"}
-    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $4 == host_name && $3 == agent_type && $5 == ":-)"){f=1}} END {exit !f}' host_name=$host_name agent_type="$agent_type"
+    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $4 == host_name && $3 == agent_type && $6 == ":-)"){f=1}} END {exit !f}' host_name=$host_name agent_type="$agent_type"
 }
 
 function get_neutron_agent_hosts() {
     local agent_type=${1:-"HyperV agent"}
-    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $3 == agent_type && $5 == ":-)"){ print $4 }}' agent_type="$agent_type"
+    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $3 == agent_type && $6 == ":-)"){ print $4 }}' agent_type="$agent_type"
 }
 
 function exec_with_retry () {


### PR DESCRIPTION
python-neutronclient's command "neutron agent-list" now displays the columns in a different order. This causes the check to fail and the build to be marked as failed.