### PR TITLE
Clean *.pyc files on pull

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -228,6 +228,7 @@ function pull_all_git_repos() {
             git checkout $repo_branch_name
             git reset --hard
             git clean -f -d
+            find . -name *.pyc -delete
             git pull $remote_name $repo_branch_name
             popd
         fi


### PR DESCRIPTION
When testing an older branch, the devstack setup might fail when setting up project databases. It will notice *.pyc db migration scripts, but no *.py files, raising an exception.

Cleanup all project *.pyc files on pull_all_git_repos.