### PR TITLE
Adds tempest config options

### DIFF
--- a/exclude-tests-default.txt
+++ b/exclude-tests-default.txt
@@ -1,9 +1,3 @@
-# Hyper-V does not support attaching vNics to a running instance before Threshold
-# On Threshold it is supported, requiring Generation 2 
-tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces
-tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestXML.test_create_list_show_delete_interfaces
-tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_hotplug_nic
-
 # Unsupported consoles (Hyper-V uses RDP, not VNC or SPICE)
 tempest.api.compute.v3.servers.test_server_actions.ServerActionsV3Test.test_get_spice_console
 tempest.api.compute.v3.servers.test_server_actions.ServerActionsV3Test.test_get_vnc_console

--- a/local.sh
+++ b/local.sh
@@ -26,6 +26,9 @@ TEMPEST_CONFIG=/opt/stack/tempest/etc/tempest.conf
 iniset $TEMPEST_CONFIG compute volume_device_name "sdb"
 iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
 iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi $DEVSTACK_LIVE_MIGRATION
+iniset $TEMPEST_CONFIG compute-feature-enabled interface_attach $DEVSTACK_INTERFACE_ATTACH
+
+iniset $TEMPEST_CONFIG validation run_validation true
 
 iniset $TEMPEST_CONFIG scenario img_dir $DEVSTACK_IMAGES_DIR
 iniset $TEMPEST_CONFIG scenario img_file $DEVSTACK_IMAGE_FILE

--- a/run.sh
+++ b/run.sh
@@ -360,6 +360,7 @@ do
 
     unset DEVSTACK_LIVE_MIGRATION
     unset DEVSTACK_SAME_HOST_RESIZE
+    unset DEVSTACK_INTERFACE_ATTACH
     unset DEVSTACK_HEAT_IMAGE_FILE
     unset DEVSTACK_IMAGE_FILE
     unset DEVSTACK_IMAGES_DIR
@@ -368,6 +369,7 @@ do
     eval "devstack_config=(`get_config_test_devstack $test_name`)"
     export DEVSTACK_LIVE_MIGRATION=${devstack_config[live_migration]}
     export DEVSTACK_SAME_HOST_RESIZE=${devstack_config[allow_resize_to_same_host]}
+    export DEVSTACK_INTERFACE_ATTACH=false
 
     image_url="${devstack_config[image_url]}"
     check_get_image $image_url "$images_dir"


### PR DESCRIPTION
Adds interface_attach config option. This config option
refers to the ability to hotplug vNICs on running VMs.
This can only be done on Windows Hyper-V / Server 2016
with Generation 2 VMs.
Removes vNIC hotplug tests from exlude list.

Adds run_validation config option. With this config option,
the tests will also validate the operations (e.g.: it will
SSH into the guest).