### PR TITLE
Cleans up test exclude list

### DIFF
--- a/exclude-tests-default.txt
+++ b/exclude-tests-default.txt
@@ -2,27 +2,9 @@
 tempest.api.compute.v3.servers.test_server_actions.ServerActionsV3Test.test_get_spice_console
 tempest.api.compute.v3.servers.test_server_actions.ServerActionsV3Test.test_get_vnc_console
 
-# See Neutron bug https://bugs.launchpad.net/neutron/+bug/1277285
-# Note that corresponding JSON tests pass
-tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestXML.test_add_remove_network_from_dhcp_agent
-tempest.api.network.admin.test_l3_agent_scheduler.L3AgentSchedulerTestXML.
-tempest.api.network.admin.test_agent_management.AgentManagementTestXML.
-
 # See Tempest bug: https://bugs.launchpad.net/tempest/+bug/1363986
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_cross_tenant_traffic
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_multiple_security_groups
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_port_update_new_security_group
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_port_security_disable_security_group
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_in_tenant_traffic
-
-# Fails on DevStack. Not related to Hyper-V
-tempest.scenario.test_load_balancer_basic.TestLoadBalancerBasic.test_load_balancer_basic
-
-# Fails on DevStack. requires investigation.
-tempest.scenario.test_network_advanced_server_ops.TestNetworkAdvancedServerOps.test_server_connectivity_rebuild
-
-# Fails on DevStack. requires investigation.
-# Note that corresponding XML tests pass
-tempest.api.compute.admin.test_simple_tenant_usage.TenantUsagesTestJSON.test_get_usage_tenant
-tempest.api.compute.admin.test_simple_tenant_usage.TenantUsagesTestJSON.test_get_usage_tenant_with_non_admin_user
-


### PR DESCRIPTION
Tempest no longer has XML tests.
Remove other excluded tests.