### PR TITLE
Adds RPCBACKENDUSER installer argument

### DIFF
--- a/windows/installnova.ps1
+++ b/windows/installnova.ps1
@@ -57,6 +57,7 @@ $msiArgs = "/i $msi /qn /l*v $msiLogPath " + `
 "GLANCEHOST=$DevstackHost " +
 "RPCBACKEND=RabbitMQ " +
 "RPCBACKENDHOST=$DevstackHost " +
+"RPCBACKENDUSER=stackrabbit" +
 "RPCBACKENDPASSWORD=Passw0rd " +
 
 "INSTANCESPATH=C:\OpenStack\Instances " +


### PR DESCRIPTION
By default, devstack uses "stackrabbit" as an RPC guest. Without this, compute nodes fail to authenticate.