### PR TITLE
Adds missing whitespace

### DIFF
--- a/windows/installnova.ps1
+++ b/windows/installnova.ps1
@@ -57,7 +57,7 @@ $msiArgs = "/i $msi /qn /l*v $msiLogPath " + `
 "GLANCEHOST=$DevstackHost " +
 "RPCBACKEND=RabbitMQ " +
 "RPCBACKENDHOST=$DevstackHost " +
-"RPCBACKENDUSER=stackrabbit" +
+"RPCBACKENDUSER=stackrabbit " +
 "RPCBACKENDPASSWORD=Passw0rd " +
 
 "INSTANCESPATH=C:\OpenStack\Instances " +


### PR DESCRIPTION
There is no space between stackrabbit and RPCBACKENDPASSWORD, which results in a bad config being passed to the installer.