### PR TITLE
Adds test_network_v6 to exclude list

### DIFF
--- a/exclude-tests-default.txt
+++ b/exclude-tests-default.txt
@@ -8,3 +8,6 @@ tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_port_update_new_security_group
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_port_security_disable_security_group
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps.test_in_tenant_traffic
+
+# current version of cirros does not have the ping6 command.
+tempest.scenario.test_network_v6.TestGettingAddress


### PR DESCRIPTION
The current version of cirros does not have the ping6 command, causing the test_network_v6 tests to fail. Excluding them until the newest cirros is being used.