### PR TITLE
installer: Adds http prefix

### DIFF
--- a/windows/installnova.ps1
+++ b/windows/installnova.ps1
@@ -55,7 +55,7 @@ $msiArgs = "/i $msi /qn /l*v $msiLogPath " + `
 "ADDLOCAL=" + ($features -join ",") + " " +
 
 "INSTALLDIR=C:\OpenStack\cloudbase\nova " +
-"GLANCEHOST=$DevstackHost " +
+"GLANCEHOST=http://$DevstackHost " +
 "RPCBACKEND=RabbitMQ " +
 "RPCBACKENDHOST=$DevstackHost " +
 "RPCBACKENDUSER=stackrabbit " +


### PR DESCRIPTION
nova generates a lot of warnings because of the missing http prefix. Adding it will make the logs cleaner.