### PR TITLE
Cleans up only git repos

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -409,7 +409,7 @@ do
     
     # NOTE(claudiub): some projects might have some changes done locally, meaning that the branch
     # can't be switched easily. This command will hard-reset and clean every git repo in /opt/stack/
-    find /opt/stack/ -type d -maxdepth 1 -mindepth 1 -execdir sh -c 'cd $0; git reset --hard && git clean -f -d' {} +
+    find /opt/stack/ -name *.git -type d -maxdepth 2 -mindepth 2 -execdir sh -c 'git reset --hard && git clean -f -d' {} +
 
     if [ -n "${devstack_config[Q_ML2_TENANT_NETWORK_TYPE]}" ]; then
         sed -i "s/Q_ML2_TENANT_NETWORK_TYPE=.*/Q_ML2_TENANT_NETWORK_TYPE=${devstack_config[Q_ML2_TENANT_NETWORK_TYPE]}/g" $devstack_dir/local.conf


### PR DESCRIPTION
Previous patch performed git reset and git clean on all folders in /opt/stack.
This patch ensures that the commands are only executed in folders that
have a .git folder, meaning that they are git repositories.