### PR TITLE
Fixes tests

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -9,7 +9,7 @@ else
 fi
 
 nova flavor-delete 42
-nova flavor-create m1.nano 42 96 1 1
+nova flavor-create m1.nano 42 128 1 1
 
 nova flavor-delete 84
 nova flavor-create m1.micro 84 128 2 1
@@ -37,3 +37,4 @@ iniset $TEMPEST_CONFIG scenario img_disk_format vhd
 IMAGE_REF=`iniget $TEMPEST_CONFIG compute image_ref`
 iniset $TEMPEST_CONFIG compute image_ref_alt $IMAGE_REF
 
+sudo ip link set br-ex mtu 1450

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -11,7 +11,7 @@ BASEDIR=$(dirname $0)
 
 . $BASEDIR/utils.sh
 
-pip install -r "$tests_dir/requirements.txt"
+sudo pip install -r "$tests_dir/requirements.txt"
 
 tests_file=$(tempfile)
 $BASEDIR/get-tests.sh $tests_dir $test_suite > $tests_file


### PR DESCRIPTION
96MB of ram were not enough to mount the device volume, so an
increase to 128MB fixed the problem. Default mtu, of 1500, with
the headers of vxlan was greater than what the network supported,
so it had to be decreased to 1450 inside the container. Elevated
rights were required to install the requirements.