### PR TITLE
Skips LiveMigration feature inside a cluster

### DIFF
--- a/windows/Utils.psm1
+++ b/windows/Utils.psm1
@@ -85,7 +85,11 @@ function InstallMSI($MSIPath, $DevstackHost, $Password)
     "FreeRDP"
     )
 
-    if($domainName) {
+    $isInCluster = Get-Service | Where { $_.Name -eq "ClusSvc" }
+
+    # Cluster migration network tags cannot be modified for a node that
+    # is inside a cluster
+    if($domainName -and !$isInCluster) {
         $features += "LiveMigration"
     }
 


### PR DESCRIPTION
This commit does not add LiveMigration as a feature if the node to
which the MSI is being run, is inside a cluster. Cluster migration
network tags cannot be modified while being part of a cluster.