### PR TITLE
Fixes neutron agent-list on kilo

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -503,7 +503,7 @@ do
         run_ssh $DEVSTACK_IP_ADDR "sudo ifconfig eth1 ${devstack_config[TUNNEL_ENDPOINT_IP]}/24" $ssh_key
     fi
 
-    run_ssh $DEVSTACK_IP_ADDR "sudo DEBIAN_FRONTEND=noninteractive apt-get install mongodb -y > /dev/null ; sudo rm /var/lib/mongodb/mongod.lock ; sudo service mongodb restart > /dev/null "
+    run_ssh $DEVSTACK_IP_ADDR "sudo DEBIAN_FRONTEND=noninteractive apt-get install mongodb -y > /dev/null ; sudo rm /var/lib/mongodb/mongod.lock ; sudo service mongodb restart > /dev/null" $ssh_key
 
     pids=()
     run_ssh $DEVSTACK_IP_ADDR "source $container_test_dir/utils.sh ; exec_with_retry 1 0 stack_devstack $container_devstack_logs $devstack_dir" $ssh_key &

--- a/utils.sh
+++ b/utils.sh
@@ -135,12 +135,12 @@ function get_nova_service_hosts() {
 function check_neutron_agent_up() {
     local host_name=$1
     local agent_type=${2:-"HyperV agent"}
-    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $4 == host_name && $3 == agent_type && $6 == ":-)"){f=1}} END {exit !f}' host_name=$host_name agent_type="$agent_type"
+    neutron agent-list -c agent_type -c host -c alive | awk 'BEGIN { FS = "[ ]*\\|[ ]*" }; {if (NR > 3 && $2 == agent_type && $3 == host_name && $4 == ":-)"){f=1}} END {exit !f}' host_name=$host_name agent_type="$agent_type"
 }
 
 function get_neutron_agent_hosts() {
     local agent_type=${1:-"HyperV agent"}
-    neutron agent-list |  awk 'BEGIN { FS = "[ ]*\\|[ ]+" }; {if (NR > 3 && $3 == agent_type && $6 == ":-)"){ print $4 }}' agent_type="$agent_type"
+    neutron agent-list -c agent_type -c host -c alive | awk 'BEGIN { FS = "[ ]*\\|[ ]*" }; {if (NR > 3 && $2 == agent_type && $4 == ":-)"){ print $3 }}' agent_type="$agent_type"
 }
 
 function exec_with_retry () {


### PR DESCRIPTION
Since Mitaka, neutron agent-list has a new column called
'availability_zone'. Passing the result to awk and testing for
the agent_type column this is located in position 5 for Kilo,
and for the upper versions on 6.