### PR TITLE
Adds job HyperV2016_OVS_VXLAN_VHDX

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -337,7 +337,7 @@ HyperV2012_VHD_v1:
           debug: true
         AGENT:
           enable_metrics_collection: false
-HyperV2016_OVS_VXLAN_VHDX:
+HyperV2016_OVS_KILO_VXLAN_VHDX:
   use_ovs: true
   test_suite: default
   devstack:
@@ -381,6 +381,60 @@ HyperV2016_OVS_VXLAN_VHDX:
           debug: true
         SECURITYGROUP:
           firewall_driver: neutron.plugins.hyperv.agent.security_groups_driver.HyperVSecurityGroupsDriver
+          enable_security_group: true
+        AGENT:
+          tunnel_types: vxlan
+          enable_metrics_collection: false
+        OVS:
+          local_ip: 14.14.14.2
+          tunnel_bridge: br-tun
+          integration_bridge: br-int
+          tenant_network_type: vxlan
+          enable_tunneling: true
+HyperV2016_OVS_VXLAN_VHDX:
+  use_ovs: true
+  test_suite: default
+  devstack:
+    live_migration: true
+    allow_resize_to_same_host: false
+    image_url: https://cloudbase.it/downloads/cirros-0.3.4-x86_64.vhdx.gz
+    heat_image_url: https://www.cloudbase.it/downloads/Fedora-x86_64-20-20140618-sda.vhdx.gz
+    Q_ML2_TENANT_NETWORK_TYPE: vxlan
+    OVS_ENABLE_TUNNELING: true
+    TUNNEL_ENDPOINT_IP: 14.14.14.3
+  hosts:
+    NUC01HV2016OVS:
+      nova.conf:
+        DEFAULT:
+          allow_resize_to_same_host: false
+          debug: true
+          vif_plugging_timeout: 0
+      neutron_ovs_agent.conf:
+        DEFAULT:
+          debug: true
+        SECURITYGROUP:
+          firewall_driver: openvswitch
+          enable_security_group: true
+        AGENT:
+          tunnel_types: vxlan
+          enable_metrics_collection: false
+        OVS:
+          local_ip: 14.14.14.1
+          tunnel_bridge: br-tun
+          integration_bridge: br-int
+          tenant_network_type: vxlan
+          enable_tunneling: true
+    NUC02HV2016OVS:
+      nova.conf:
+        DEFAULT:
+          allow_resize_to_same_host: false
+          debug: true
+          vif_plugging_timeout: 0
+      neutron_ovs_agent.conf:
+        DEFAULT:
+          debug: true
+        SECURITYGROUP:
+          firewall_driver: openvswitch
           enable_security_group: true
         AGENT:
           tunnel_types: vxlan


### PR DESCRIPTION
This commits changes the old HyperV2016_OVS_VXLAN_VHDX job to
HyperV2016_OVS_KILO_VXLAN_VHDX because the firewall_driver config
has to remain "neutron.plugins.hyperv.agent.security_groups_driver
.HyperVSecurityGroupsDriver" while on upper versions of devstack
this path no longer exists. Adds another job of
HyperV2016_OVS_VXLAN_VHDX which has the firewall_driver config
set to "openvswitch".