### PR TITLE
Cleans up allocated loop devices

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -619,6 +619,9 @@ done
 echo "Destroying lxc container $DEVSTACK_CONTAINER_NAME"
 destroy_container $DEVSTACK_CONTAINER_NAME
 
+echo "Clearing loopback devices used by the container"
+clear_loop_devices $DEVSTACK_CONTAINER_NAME
+
 echo "Done!"
 
 exit $has_failed_tests

--- a/utils.sh
+++ b/utils.sh
@@ -337,6 +337,13 @@ function destroy_container() {
     sudo lxc-destroy -n $container_name || true
 }
 
+function clear_loop_devices() {
+    local container_name=$1
+    # expected output of losetup --all:
+    #/dev/loop1: [fc00]:23465059 (/opt/stack/data/devstack-stable-ocata-lvmdriver-1-backing-file
+    sudo losetup --all | grep $container_name | awk -F':' '{print $1}' | xargs sudo losetup --detach
+}
+
 function run_tempest() {
     local test_suite=$1
     local test_logs_dir=$2


### PR DESCRIPTION
loop devices are allocated per container, and there are only 8
available loop devices. We need to clean them up, so we don't run
out of them, otherwise devstack will fail to setup.