### PR TITLE
clears container from known hosts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -622,6 +622,9 @@ destroy_container $DEVSTACK_CONTAINER_NAME
 echo "Clearing loopback devices used by the container"
 clear_loop_devices $DEVSTACK_CONTAINER_NAME
 
+echo "Clearing container from known hosts"
+ssh-keygen -f ~/.ssh/known_hosts -R $DEVSTACK_IP_ADDR
+
 echo "Done!"
 
 exit $has_failed_tests


### PR DESCRIPTION
Because the containers are being added to the known_hosts list, ssh-ing into a container having an IP which was previously allocated to another container will fail.