### PR TITLE
Escapes backslashes on exec_with_retry

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -148,6 +148,10 @@ function exec_with_retry () {
     local interval=${2}
     local cmd=${@:3}
 
+    # cmd might have backslashes that must be escaped. when evaluating it,
+    # the backslashes are interpreted, and they shouldn't be.
+    cmd=$(echo $cmd | sed -e 's/\\/\\\\/g')
+
     local counter=0
     while [ $counter -lt $max_retries ]; do
         local exit_code=0


### PR DESCRIPTION
When evaluating an expression / cmd, backslashes are interpreted, which can be an undesired effect.

For example, executing:

exec_with_retry 2 1 get_win_config_files HOST C:\OpenStack\cloudbase\nova\etc LOCAL_PATH

The above path becomes: C:OpenStackcloudbasenovaetc, which is an invalid path.