### PR TITLE
Adds RPCTRANSPORTURL

### DIFF
--- a/windows/Utils.psm1
+++ b/windows/Utils.psm1
@@ -175,6 +175,7 @@ function InstallComputeMSI($MSIPath, $DevstackHost, $Password)
     "RPCBACKENDHOST=$DevstackHost " +
     "RPCBACKENDUSER=stackrabbit " +
     "RPCBACKENDPASSWORD=$Password " +
+    "RPCTRANSPORTURL=rabbit://stackrabbit:$Password@$DevstackHost`:5672/ " +
 
     "INSTANCESPATH=C:\OpenStack\Instances " +
     "LOGDIR=C:\OpenStack\Log " +


### PR DESCRIPTION
OpenStack Pike and newer releases rely on the configured transport_url. The installers will include the RPCTRANSPORTURL option.